### PR TITLE
Handle path and 'ps' on git for windows

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,8 +42,8 @@ install-test:
 .PHONY: test
 test: install-test clean build
 	@chmod +x "./utils/tests.sh"; sync; \
-	export SECRET_PROJECT_ROOT="${PWD}"; \
-	export PATH="${PWD}/vendor/bats-core/bin:${PWD}:${PATH}"; \
+	export SECRET_PROJECT_ROOT="$(shell echo $${PWD})"; \
+	export PATH="$(shell echo $${PWD})/vendor/bats-core/bin:$(shell echo $${PWD}):$(shell echo $${PATH})"; \
 	"./utils/tests.sh"
 
 #

--- a/Makefile
+++ b/Makefile
@@ -42,6 +42,9 @@ install-test:
 .PHONY: test
 test: install-test clean build
 	@chmod +x "./utils/tests.sh"; sync; \
+	# Under git for windows '$PATH' is set to windows paths, e.g. C:\Something; \
+	# Using a sub-shell we get the *nix paths, e.g. /c/Something; \
+	# Sub-shell works for *nix as well; \
 	export SECRET_PROJECT_ROOT="$(shell echo $${PWD})"; \
 	export PATH="$(shell echo $${PWD})/vendor/bats-core/bin:$(shell echo $${PWD}):$(shell echo $${PATH})"; \
 	"./utils/tests.sh"

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -32,9 +32,9 @@ GPGTEST="$SECRETS_GPG_COMMAND --homedir=$TEST_GPG_HOMEDIR --no-permission-warnin
 
 # Platform stuff:
 if [[ "$GITSECRET_DIST" == "windows" ]]; then
-PS_CMD="ps -l -u";
+  PS_CMD="ps -l -u";
 else
-PS_CMD="ps -wx -U";
+  PS_CMD="ps -wx -U";
 fi
 
 # Personal data:

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -73,7 +73,7 @@ function test_user_password {
 function stop_gpg_agent {
   local username=$(id -u -n)
   ${PS_CMD} "$username" | gawk \
-    '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("echo -9 "$1) } }' \
+    '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("kill -9 "$1) } }' \
     > /dev/null 2>&1
 }
 

--- a/tests/_test_base.bash
+++ b/tests/_test_base.bash
@@ -30,6 +30,12 @@ BEGIN { OFS=":"; FS=":"; }
 # This command is used with absolute homedir set and disabled warnings:
 GPGTEST="$SECRETS_GPG_COMMAND --homedir=$TEST_GPG_HOMEDIR --no-permission-warning --batch"
 
+# Platform stuff:
+if [[ "$GITSECRET_DIST" == "windows" ]]; then
+PS_CMD="ps -l -u";
+else
+PS_CMD="ps -wx -U";
+fi
 
 # Personal data:
 
@@ -66,8 +72,8 @@ function test_user_password {
 
 function stop_gpg_agent {
   local username=$(id -u -n)
-  ps -wx -U "$username" | gawk \
-    '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("kill -9 "$1) } }' \
+  ${PS_CMD} "$username" | gawk \
+    '/gpg-agent --homedir/ { if ( $0 !~ "awk" ) { system("echo -9 "$1) } }' \
     > /dev/null 2>&1
 }
 


### PR DESCRIPTION
This should fix the path issue for git for windows. Chocolatey `make` has $PATH set to windows paths but shell script needs unix paths, which we can get from a subshell in make. This should work on *nix as well